### PR TITLE
Fix line length when it contains a line feed

### DIFF
--- a/addon/globalPlugins/cursorLocator/__init__.py
+++ b/addon/globalPlugins/cursorLocator/__init__.py
@@ -153,7 +153,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def removeCarriageReturn(self, text):
 		try:
-			if ord(text[-1]) == 13:
+			if ord(text[-1]) == 13 or ord(text[-1]) == 10:
+				text = text[:-1]
+			if ord(text[-1]) == 13 or ord(text[-1]) == 10:
 				text = text[:-1]
 		except IndexError:
 			pass


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
Fixes issue #5
### Summary of the issue:
In programs like Notepad, the line length iscorrectly reported in the last line.
### Description of how this pull request fixes the issue:
Try to remove twice \r and \n characters (ord 13 and 10).
### Testing performed:
None yet
### Known issues with pull request:
None
### Change log entry:
None