### PR TITLE
Add brazilian and european portuguese translations

### DIFF
--- a/addon/doc/pt_BR/readme.md
+++ b/addon/doc/pt_BR/readme.md
@@ -1,0 +1,30 @@
+# Localizador do cursor #
+* Autor: Noelia Ruiz Martínez.
+* Compatibilidade: 2020.4.
+
+Este extra possibilita saber a posição do cursor do sistema em relação ao início da linha actual, enquanto se escreve para adicionar texto em controlos multilinhas.
+
+## Configurações do localizador do cursor ##
+
+Este painel está disponível no menu do NVDA, submenu Preferências, diálogo Configurações.
+
+Oferece as seguintes opções:
+
+* Indicação do início da linha: Quando este controlo é verificado, um tom baixo anunciará se o cursor está no início da linha actual enquanto o texto é adicionado. (Verificado por padrão).
+* Indicação do comprimento da linha: Pode escrever ou escolher o comprimento da linha (número de caracteres entre 0 e 600), que será anunciado por um tom alto quando for atingido. (O valor padrão é 80 caracteres).
+* Tonalidade de som para o início da linha: Pode escrever ou seleccionar um valor entre 20 e 20.000. (O valor padrão é 400 hertzs).
+* Comprimento do som para o início da linha: Você pode digitar ou selecionar um valor entre 20 e 2000. (O valor padrão é 50 milissegundos).
+* Teste de som para início de linha: Pressione este botão para testar o som configurado para início de linha.
+* Tonalidade de som para final de linha: Pode escrever ou seleccionar um valor entre 20 e 20.000. (O valor padrão é 1000 hertzs).
+* Comprimento do som para o fim da linha: Você pode digitar ou selecionar um valor entre 20 e 2000. (O valor padrão é 50 milissegundos).
+* Teste de som para fim de linha: Pressione este botão para testar o som configurado para fim de linha.
+
+## Comandos ##
+
+Pode modificar os atalhos para os seguintes comandos, através do menu do NVDA> submenu Preferências> caixa de diálogo definir comandos.
+
+* NVDA + control + shift + l: Quando possível, indica o comprimento da linha actual (categoria do sistema).
+* Não atribuído: Mostra a caixa de diálogo de configurações do Cursor Locator (categoria Config).
+
+## Alterações para 1.0 ##
+* Versão inicial

--- a/addon/doc/pt_PT/readme.md
+++ b/addon/doc/pt_PT/readme.md
@@ -1,0 +1,30 @@
+# Localizador do cursor #
+* Autor: Noelia Ruiz Martínez.
+* Compatibilidade: 2020.4.
+
+Este extra possibilita saber a posição do cursor do sistema em relação ao início da linha actual, enquanto se escreve para adicionar texto em controlos multilinhas.
+
+## Configurações do localizador do cursor ##
+
+Este painel está disponível no menu do NVDA, submenu Preferências, diálogo Configurações.
+
+Oferece as seguintes opções:
+
+* Indicação do início da linha: Quando este controlo é verificado, um tom baixo anunciará se o cursor está no início da linha actual enquanto o texto é adicionado. (Verificado por padrão).
+* Indicação do comprimento da linha: Pode escrever ou escolher o comprimento da linha (número de caracteres entre 0 e 600), que será anunciado por um tom alto quando for atingido. (O valor padrão é 80 caracteres).
+* Tonalidade de som para o início da linha: Pode escrever ou seleccionar um valor entre 20 e 20.000. (O valor padrão é 400 hertzs).
+* Comprimento do som para o início da linha: Você pode digitar ou selecionar um valor entre 20 e 2000. (O valor padrão é 50 milissegundos).
+* Teste de som para início de linha: Pressione este botão para testar o som configurado para início de linha.
+* Tonalidade de som para final de linha: Pode escrever ou seleccionar um valor entre 20 e 20.000. (O valor padrão é 1000 hertzs).
+* Comprimento do som para o fim da linha: Você pode digitar ou selecionar um valor entre 20 e 2000. (O valor padrão é 50 milissegundos).
+* Teste de som para fim de linha: Pressione este botão para testar o som configurado para fim de linha.
+
+## Comandos ##
+
+Pode modificar os atalhos para os seguintes comandos, através do menu do NVDA> submenu Preferências> caixa de diálogo definir comandos.
+
+* NVDA + control + shift + l: Quando possível, indica o comprimento da linha actual (categoria do sistema).
+* Não atribuído: Mostra a caixa de diálogo de configurações do Cursor Locator (categoria Config).
+
+## Alterações para 1.0 ##
+* Versão inicial

--- a/addon/locale/pt_BR/LC_MESSAGES/nvda.po
+++ b/addon/locale/pt_BR/LC_MESSAGES/nvda.po
@@ -1,0 +1,97 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the cursorLocator package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: cursorLocator 1.4.1-dev\n"
+"Report-Msgid-Bugs-To: nvda-translations@groups.io\n"
+"POT-Creation-Date: 2021-01-30 17:47+0100\n"
+"PO-Revision-Date: 2021-02-05 17:40+0000\n"
+"Language-Team: Equipa portuguesa do NVDA. Angelo Abrantes e Rui Fontes\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.4.2\n"
+"Last-Translator: Ângelo Abrantes <ampa4374@gmail.com>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: pt_PT\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#. Translators: Description of the Cursor Locator panel.
+#: addon\globalPlugins\cursorLocator\__init__.py:44
+msgid "Configure {}"
+msgstr "Configurar {}"
+
+#. Translators: Label for a group of Cursor Locator options.
+#: addon\globalPlugins\cursorLocator\__init__.py:51
+msgid "Line properties"
+msgstr "Propriedades de linha"
+
+#. Translators: Label for the Cursor Locator panel.
+#: addon\globalPlugins\cursorLocator\__init__.py:58
+msgid "&Report start of line"
+msgstr "&Indicar princípio de linha"
+
+#: addon\globalPlugins\cursorLocator\__init__.py:63
+msgid "Report &line length:"
+msgstr "Indicar &tamanho de linha:"
+
+#. Translators: Label for a group of Cursor Locator options.
+#: addon\globalPlugins\cursorLocator\__init__.py:68
+msgid "Sound for start of line"
+msgstr "Som de princípio de linha"
+
+#: addon\globalPlugins\cursorLocator\__init__.py:76
+msgid "&Pitch of sound for start of line:"
+msgstr "&Tom do som de princípio de linha:"
+
+#: addon\globalPlugins\cursorLocator\__init__.py:82
+msgid "L&ength of sound for start of line:"
+msgstr "&Duração do som de princípio de linha:"
+
+#. Translators: Label for the Cursor Locator panel.
+#: addon\globalPlugins\cursorLocator\__init__.py:87
+msgid "&Test sound for start of line"
+msgstr "&Testar som de princípio de linha"
+
+#. Translators: Label for a group of Cursor Locator options.
+#: addon\globalPlugins\cursorLocator\__init__.py:92
+msgid "Sound for end of line"
+msgstr "Som de fim de linha"
+
+#: addon\globalPlugins\cursorLocator\__init__.py:100
+msgid "P&itch of sound for end of line:"
+msgstr "T&om do som de fim de linha:"
+
+#: addon\globalPlugins\cursorLocator\__init__.py:106
+msgid "Le&ngth of sound for end of line:"
+msgstr "D&uração do som de fim de linha:"
+
+#. Translators: Label for the Cursor Locator panel.
+#: addon\globalPlugins\cursorLocator\__init__.py:111
+msgid "Test s&ound for end of line"
+msgstr "Testar s&om de fim de linha"
+
+#. Translators: Message presented in input mode.
+#: addon\globalPlugins\cursorLocator\__init__.py:148
+msgid "Shows the {} settings."
+msgstr "Mostra as configurações."
+
+#. Translators: Message presented in input help mode.
+#: addon\globalPlugins\cursorLocator\__init__.py:190
+msgid "Reports the length of the current line."
+msgstr "Indica o tamanho da linha actual."
+
+#. Add-on summary, usually the user visible name of the addon.
+#. Translators: Summary for this add-on to be shown on installation and add-on information.
+#: buildVars.py:17
+msgid "Cursor Locator"
+msgstr "Cursor Locator"
+
+#. Add-on description
+#. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
+#: buildVars.py:20
+msgid "Reports cursor positions while typing on multiline edit controls."
+msgstr "Indica as posições do cursor ao escreveres  em controlos de edição de várias linhas."

--- a/addon/locale/pt_PT/LC_MESSAGES/nvda.po
+++ b/addon/locale/pt_PT/LC_MESSAGES/nvda.po
@@ -1,0 +1,97 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the cursorLocator package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: cursorLocator 1.4.1-dev\n"
+"Report-Msgid-Bugs-To: nvda-translations@groups.io\n"
+"POT-Creation-Date: 2021-01-30 17:47+0100\n"
+"PO-Revision-Date: 2021-02-05 17:40+0000\n"
+"Language-Team: Equipa portuguesa do NVDA. Angelo Abrantes e Rui Fontes\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.4.2\n"
+"Last-Translator: Ângelo Abrantes <ampa4374@gmail.com>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: pt_PT\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+
+#. Translators: Description of the Cursor Locator panel.
+#: addon\globalPlugins\cursorLocator\__init__.py:44
+msgid "Configure {}"
+msgstr "Configurar {}"
+
+#. Translators: Label for a group of Cursor Locator options.
+#: addon\globalPlugins\cursorLocator\__init__.py:51
+msgid "Line properties"
+msgstr "Propriedades de linha"
+
+#. Translators: Label for the Cursor Locator panel.
+#: addon\globalPlugins\cursorLocator\__init__.py:58
+msgid "&Report start of line"
+msgstr "&Indicar princípio de linha"
+
+#: addon\globalPlugins\cursorLocator\__init__.py:63
+msgid "Report &line length:"
+msgstr "Indicar &tamanho de linha:"
+
+#. Translators: Label for a group of Cursor Locator options.
+#: addon\globalPlugins\cursorLocator\__init__.py:68
+msgid "Sound for start of line"
+msgstr "Som de princípio de linha"
+
+#: addon\globalPlugins\cursorLocator\__init__.py:76
+msgid "&Pitch of sound for start of line:"
+msgstr "&Tom do som de princípio de linha:"
+
+#: addon\globalPlugins\cursorLocator\__init__.py:82
+msgid "L&ength of sound for start of line:"
+msgstr "&Duração do som de princípio de linha:"
+
+#. Translators: Label for the Cursor Locator panel.
+#: addon\globalPlugins\cursorLocator\__init__.py:87
+msgid "&Test sound for start of line"
+msgstr "&Testar som de princípio de linha"
+
+#. Translators: Label for a group of Cursor Locator options.
+#: addon\globalPlugins\cursorLocator\__init__.py:92
+msgid "Sound for end of line"
+msgstr "Som de fim de linha"
+
+#: addon\globalPlugins\cursorLocator\__init__.py:100
+msgid "P&itch of sound for end of line:"
+msgstr "T&om do som de fim de linha:"
+
+#: addon\globalPlugins\cursorLocator\__init__.py:106
+msgid "Le&ngth of sound for end of line:"
+msgstr "D&uração do som de fim de linha:"
+
+#. Translators: Label for the Cursor Locator panel.
+#: addon\globalPlugins\cursorLocator\__init__.py:111
+msgid "Test s&ound for end of line"
+msgstr "Testar s&om de fim de linha"
+
+#. Translators: Message presented in input mode.
+#: addon\globalPlugins\cursorLocator\__init__.py:148
+msgid "Shows the {} settings."
+msgstr "Mostra as configurações."
+
+#. Translators: Message presented in input help mode.
+#: addon\globalPlugins\cursorLocator\__init__.py:190
+msgid "Reports the length of the current line."
+msgstr "Indica o tamanho da linha actual."
+
+#. Add-on summary, usually the user visible name of the addon.
+#. Translators: Summary for this add-on to be shown on installation and add-on information.
+#: buildVars.py:17
+msgid "Cursor Locator"
+msgstr "Cursor Locator"
+
+#. Add-on description
+#. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
+#: buildVars.py:20
+msgid "Reports cursor positions while typing on multiline edit controls."
+msgstr "Indica as posições do cursor ao escreveres  em controlos de edição de várias linhas."

--- a/changelog.md
+++ b/changelog.md
@@ -1,2 +1,3 @@
-## Changes for 1.4.3-dev (PR #4) ##
-* Added french translation.
+## Changes for 1.5-dev (PR #6) ##
+* Fixed line length when the cursor isn't placed on the last line in programs like Notepad (issue #5).
+


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
Missing portuguese translations
### Description of how this pull request fixes the issue:
Added pt_BR and pt_PT .md and .po files, sent by Ângelo Miguel Abrantes
### Testing performed:
Installed the add-on containing portuguese translations.
### Known issues with pull request:
None
### Change log entry:
None