### PR TITLE
Add ability to repeat notifications

### DIFF
--- a/.github/workflows/testWithUnittest.yaml
+++ b/.github/workflows/testWithUnittest.yaml
@@ -1,0 +1,15 @@
+name: Test with unittest
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+
+  test:
+    uses: nvdaes/nvdaAddonWorkflows/.github/workflows/testWithUnittest.yaml@main
+    

--- a/addon/globalPlugins/cursorLocator/utils.py
+++ b/addon/globalPlugins/cursorLocator/utils.py
@@ -1,0 +1,41 @@
+# -*- coding: UTF-8 -*-
+
+# cursorLocator/utils.py
+# Copyright (C) 2022 Noelia Ruiz Martínez
+# Released under GPL 2
+
+import config
+
+
+def getReportLineLength() -> int:
+	return config.conf["cursorLocator"]["reportLineLength"]
+
+
+def getMaxStartNotificationNumber() -> int:
+	return config.conf["cursorLocator"]["maxStartNotificationNumber"]
+
+
+def getMaxEndNotificationNumber() -> int:
+	return config.conf["cursorLocator"]["maxEndNotificationNumber"]
+
+
+def shouldReportStartOfLine(text: str) -> bool:
+	reportLineLength = 1
+	if len(text) < reportLineLength:
+		return False
+	if shouldReportEndOfLine(text):
+		return False
+	maxStartNotificationNumber = getMaxStartNotificationNumber()
+	if len(text) < (reportLineLength + maxStartNotificationNumber):
+		return True
+	return False
+
+
+def shouldReportEndOfLine(text: str) -> bool:
+	reportLineLength = getReportLineLength()
+	if not reportLineLength or len(text) < reportLineLength:
+		return False
+	maxEndNotificationNumber = getMaxEndNotificationNumber()
+	if len(text) < (reportLineLength + maxEndNotificationNumber):
+		return True
+	return False

--- a/readme.md
+++ b/readme.md
@@ -12,8 +12,9 @@ This panel is available from NVDA's menu, Preferences submenu, Settings dialog.
 
 It provides the following options:
 
-* Report start of line: When this control is checked, a low tone will announce if the caret is at the start of the current line while text is been added. (Checked by default).
 * Report line length: You can type or choose a line length (number of characters between 0 and 600), which will be announced by a hight tone when it's reached. (The default value is 80 characters).
+* Maximum number of beeps for start of line notification: You can type or select a value between 0 and 600. The default value is 0.
+* Maximum number of beeps for end of line notification: You can type or select a value between 0 and 600. The default value is 0.
 * Pitch of sound for start of line: You can type or select a value between 20 and 20000. (The default value is 400 hertzs).
 * Length of sound for start of line: You can type or select a value between 20 and 2000. (The default value is 50 milliseconds).
 * Test sound for start of line: Press this button to test the configured sound for start of line.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,10 +22,11 @@ del sys.path[-1]
 
 confspec = {
 	"reportLineLength": 0,
-		"maxStartNotificationNumber": 0,
+	"maxStartNotificationNumber": 0,
 	"maxEndNotificationNumber": 0
 }
 config.conf["cursorLocator"] = confspec
+
 
 class TestUtilsConfigFunctions(TestCase):
 
@@ -35,11 +36,17 @@ class TestUtilsConfigFunctions(TestCase):
 
 	def test_getMaxStartNotificationNumber(self):
 		maxStartNotificationNumber = config.conf["cursorLocator"]["maxStartNotificationNumber"]
-		self.assertEqual(utils.getMaxStartNotificationNumber(), maxStartNotificationNumber, f"shold be {maxStartNotificationNumber}")
+		self.assertEqual(
+			utils.getMaxStartNotificationNumber(), maxStartNotificationNumber,
+			f"shold be {maxStartNotificationNumber}"
+		)
 
 	def test_getMaxEndNotificationNumber(self):
 		maxEndNotificationNumber = config.conf["cursorLocator"]["maxEndNotificationNumber"]
-		self.assertEqual(utils.getMaxEndNotificationNumber(), maxEndNotificationNumber, f"shold be {maxEndNotificationNumber}")
+		self.assertEqual(
+			utils.getMaxEndNotificationNumber(), maxEndNotificationNumber,
+			f"shold be {maxEndNotificationNumber}"
+		)
 
 
 class TestUtilsReportStart(TestCase):
@@ -47,12 +54,12 @@ class TestUtilsReportStart(TestCase):
 	def setUp(self):
 		self.text = "H"
 		self.reportLineLength = 1
-		config.conf["cursorLocator"]["maxStartNotificationNumber"] =  1
+		config.conf["cursorLocator"]["maxStartNotificationNumber"] = 1
 
 	def tearDown(self):
 		self.text = None
 		self.reportLineLength = 0
-		config.conf["cursorLocator"]["maxStartNotificationNumber"]= 0
+		config.conf["cursorLocator"]["maxStartNotificationNumber"] = 0
 
 	def test_valid(self):
 		self.assertTrue(utils.shouldReportStartOfLine(self.text), "should be true")
@@ -64,7 +71,7 @@ class TestUtilsReportStart(TestCase):
 	def test_MaxStartNotificationNumber2(self):
 		config.conf["cursorLocator"]["maxStartNotificationNumber"] = 2
 		self.assertTrue(utils.shouldReportStartOfLine(self.text), "should be true")
-		self.text= "He"
+		self.text = "He"
 		self.assertTrue(utils.shouldReportStartOfLine(self.text), "should be true")
 		self.text = "Hel"
 		self.assertFalse(utils.shouldReportStartOfLine(self.text), "should be false")
@@ -84,12 +91,12 @@ class TestUtilsReportEnd(TestCase):
 	def setUp(self):
 		self.text = "Hello"
 		config.conf["cursorLocator"]["reportLineLength"] = 5
-		config.conf["cursorLocator"]["maxEndNotificationNumber"] =  1
+		config.conf["cursorLocator"]["maxEndNotificationNumber"] = 1
 
 	def tearDown(self):
 		self.text = None
 		config.conf["cursorLocator"]["reportLineLength"] = 0
-		config.conf["cursorLocator"]["maxEndNotificationNumber"]= 0
+		config.conf["cursorLocator"]["maxEndNotificationNumber"] = 0
 
 	def test_valid(self):
 		self.assertTrue(utils.shouldReportEndOfLine(self.text), "should be true")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2022 Noelia Ruiz Martínez
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import os
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+TOP_DIR = os.path.abspath(os.path.dirname(__file__))
+SOURCE_DIR = os.path.dirname(TOP_DIR)
+PLUGIN_DIR = os.path.join(SOURCE_DIR, "addon", "globalPlugins", "cursorLocator")
+
+config = MagicMock
+config.conf = dict()
+sys.modules['config'] = config
+sys.path.append(PLUGIN_DIR)
+import utils  # NOQA: E402
+del sys.path[-1]
+
+confspec = {
+	"reportLineLength": 0,
+		"maxStartNotificationNumber": 0,
+	"maxEndNotificationNumber": 0
+}
+config.conf["cursorLocator"] = confspec
+
+class TestUtilsConfigFunctions(TestCase):
+
+	def test_getReportLineLength(self):
+		reportLineLength = config.conf["cursorLocator"]["reportLineLength"]
+		self.assertEqual(utils.getReportLineLength(), reportLineLength, f"should be {reportLineLength}")
+
+	def test_getMaxStartNotificationNumber(self):
+		maxStartNotificationNumber = config.conf["cursorLocator"]["maxStartNotificationNumber"]
+		self.assertEqual(utils.getMaxStartNotificationNumber(), maxStartNotificationNumber, f"shold be {maxStartNotificationNumber}")
+
+	def test_getMaxEndNotificationNumber(self):
+		maxEndNotificationNumber = config.conf["cursorLocator"]["maxEndNotificationNumber"]
+		self.assertEqual(utils.getMaxEndNotificationNumber(), maxEndNotificationNumber, f"shold be {maxEndNotificationNumber}")
+
+
+class TestUtilsReportStart(TestCase):
+
+	def setUp(self):
+		self.text = "H"
+		self.reportLineLength = 1
+		config.conf["cursorLocator"]["maxStartNotificationNumber"] =  1
+
+	def tearDown(self):
+		self.text = None
+		self.reportLineLength = 0
+		config.conf["cursorLocator"]["maxStartNotificationNumber"]= 0
+
+	def test_valid(self):
+		self.assertTrue(utils.shouldReportStartOfLine(self.text), "should be true")
+
+	def test_lenText0(self):
+		self.text = ""
+		self.assertFalse(utils.shouldReportStartOfLine(self.text), "should be false")
+
+	def test_MaxStartNotificationNumber2(self):
+		config.conf["cursorLocator"]["maxStartNotificationNumber"] = 2
+		self.assertTrue(utils.shouldReportStartOfLine(self.text), "should be true")
+		self.text= "He"
+		self.assertTrue(utils.shouldReportStartOfLine(self.text), "should be true")
+		self.text = "Hel"
+		self.assertFalse(utils.shouldReportStartOfLine(self.text), "should be false")
+
+	def test_MaxStartNotificationNumber0(self):
+		config.conf["cursorLocator"]["maxStartNotificationNumber"] = 0
+		self.assertFalse(utils.shouldReportStartOfLine(self.text), "should be false")
+
+	@patch("utils.shouldReportEndOfLine")
+	def test_reportEndOfLineIsTrue(self, mockShouldReportEndOfLine):
+		mockShouldReportEndOfLine.return_value = True
+		self.assertEqual(utils.shouldReportStartOfLine(self.text), False, "should be false")
+
+
+class TestUtilsReportEnd(TestCase):
+
+	def setUp(self):
+		self.text = "Hello"
+		config.conf["cursorLocator"]["reportLineLength"] = 5
+		config.conf["cursorLocator"]["maxEndNotificationNumber"] =  1
+
+	def tearDown(self):
+		self.text = None
+		config.conf["cursorLocator"]["reportLineLength"] = 0
+		config.conf["cursorLocator"]["maxEndNotificationNumber"]= 0
+
+	def test_valid(self):
+		self.assertTrue(utils.shouldReportEndOfLine(self.text), "should be true")
+
+	def test_lenTextMinorThanReportLineLength(self):
+		self.text = "Hell"
+		self.assertFalse(utils.shouldReportEndOfLine(self.text), "should be false")
+
+	def reportLineLengthZero(self):
+		config.conf["cursorLocator"]["reportLineLength"] = 0
+		self.assertFalse(utils.shouldReportEndOfLine(self.text), "should be false")
+
+	def test_maxEndNotificationNumber2(self):
+		config.conf["cursorLocator"]["maxEndNotificationNumber"] = 2
+		self.assertTrue(utils.shouldReportEndOfLine(self.text), "should be true")
+		self.text = "Hello,"
+		self.assertTrue(utils.shouldReportEndOfLine(self.text), "should be true")
+		self.text = "Hello, "
+		self.assertFalse(utils.shouldReportEndOfLine(self.text), "should be true")
+
+	def test_MaxEndNotificationNumber0(self):
+		config.conf["cursorLocator"]["maxEndNotificationNumber"] = 0
+		self.assertFalse(utils.shouldReportEndOfLine(self.text), "should be false")


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None (requested by email).
### Summary of the issue:
Currently, it's not possible to repeat notifications, which maybe convenient, mostly for people using technologies like cochlear implants and in other cases.
### Description of how this pull request fixes the issue:
- Added an utils module which helper functions to know where start and end of line should be reported.
- - Add configuration options to repeat notifications.
- Gui and event_typedCharacter have been changed accordingly.
- Unit tests have been provided for the utils module.
### Testing performed:
- Tested manually and with unit tests.
### Known issues with pull request:
None
### Change log entry:
* Added ability to repeat notifications when reaching end and start of line.