### PR TITLE
Add support for obj.Role.DOCUMENT

### DIFF
--- a/addon/globalPlugins/cursorLocator/__init__.py
+++ b/addon/globalPlugins/cursorLocator/__init__.py
@@ -166,7 +166,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def event_typedCharacter(self, obj, nextHandler, ch):
 		nextHandler()
 		states = obj.states
-		if controlTypes.State.MULTILINE not in states or controlTypes.State.READONLY in states:
+		if controlTypes.State.MULTILINE not in states and obj.role != controlTypes.Role.DOCUMENT:
 			return
 		if not ord(ch) >= 32:
 			return

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 * Authors: Noelia Ruiz Martínez, Sergio Gómez Codina.
 * Download [stable version][1] (compatible with NVDA 2022.1 and beyond).
 
-This add-on makes possible to know the position of the system caret respect to the start of the current line, while typing to add text in multiline controls.
+This add-on makes possible to know the position of the system caret respect to the start of the current line, while typing to add text in documents or multiline controls.
 
 This feature deppends on the visual appearance of applications. Therefore, you may need to disable line adjustment or configure the add-on for different programs.
 


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None, reported by email
### Summary of the issue:
Support for Office documents and Notepad on Windows 11 is needed.
### Description of how this pull request fixes the issue:
event_typedCharacter doesn't return if controlTypes.State.MULTILINE is in obj.states, or if obj.role is controlTyPes.Role.DOCUMENT.
### Testing performed:
Tested locally.
### Known issues with pull request:
None
### Change log entry:
* Added support for Office documents, and Notepad on Windows 11.