### PR TITLE
Fix translatable message

### DIFF
--- a/addon/globalPlugins/cursorLocator/__init__.py
+++ b/addon/globalPlugins/cursorLocator/__init__.py
@@ -208,6 +208,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			info = obj.makeTextInfo(textInfos.POSITION_CARET)
 			info.expand(textInfos.UNIT_LINE)
 			lineLen = len(self.removeCarriageReturn(info.text))
-			ui.message("Line length: %d" % lineLen)
+			# Translators: message to report line length.
+			ui.message(_("Line length: %d") % lineLen)
 		except Exception:
 			pass


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None, reported via email.
### Summary of the issue:
Message to report line length is not translatable.
### Description of how this pull request fixes the issue:
It has been included in the gettext function and the corresponding comment for translators has been added.
### Testing performed:
None yet.
### Known issues with pull request:
None.
### Change log entry:
None, not needed.