### PR TITLE
Compatibility with NVDA 2023.1

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -37,7 +37,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion": "2022.1",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2022.4",
+	"addon_lastTestedNVDAVersion": "2023.1",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,8 @@ You can modify the gestures to the following commands trought the NVDA's menu, P
 * NVDA+control+shift+l: When possible, reports the lenght of the current line (System caret category).
 * Not assigned: Shows the Cursor Locator settings dialog (Config category).
 
+## Changes for 3.0 ##
+* Compatible with NVDA 2023.1.
 
 ## Changes for 2.0 ##
 * Added ability to repeat notifications when reaching end and start of line.


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
Add-ons need to be updated for NVDA 2023.1.
### Description of how this pull request fixes the issue:
Update last tested version in buildvars, and readme.
### Testing performed:
Code has been inspected.
### Known issues with pull request:
None
### Change log entry:
* Compatible with NVDA 2023.1.