### PR TITLE
Speak on demand when reporting line length

### DIFF
--- a/addon/globalPlugins/cursorLocator/__init__.py
+++ b/addon/globalPlugins/cursorLocator/__init__.py
@@ -198,6 +198,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	@script(
 		# Translators: Message presented in input help mode.
 		description=_("Reports the length of the current line."),
+		speakOnDemand=True,
 		gesture="kb:NVDA+control+shift+l"
 	)
 	def script_reportLineLength(self, gesture):

--- a/buildVars.py
+++ b/buildVars.py
@@ -35,7 +35,7 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
-	"addon_minimumNVDAVersion": "2023.2",
+	"addon_minimumNVDAVersion": "2024.1",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
 	"addon_lastTestedNVDAVersion": "2024.1",
 	# Add-on update channel (default is None, denoting stable releases,


### PR DESCRIPTION
<!-- 
Based on pull request template of NVDA:
https://github.com/nvaccess/nvda/wiki/Github-pull-request-template-explanation-and-examples
-->
## Link to issue number:
None
### Summary of the issue:
NVDA 2024.1 API version has a new speak on demand mode.
### Description of how this pull request fixes the issue:
Add speakOnDemand=True for the script to report the line length.
### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
None, thoughthis would require NVDA 2024.1.